### PR TITLE
fix: check for element key before trying to lowercase it

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const where = (key = 'name', text = '') => {
 		return all.find(element => element[key] === text)
 	}
 
-	return all.find(element => element[key].toLowerCase() === text.toLowerCase())
+	return all.find(element => elelment[key] && element[key].toLowerCase() === text.toLowerCase())
 }
 
 const getByName = text => where('name', text)


### PR DESCRIPTION
This will fix all methods that might have null in the data. (getByISO6392, getByISO6391 etc...)

Currently you cannot use these methods at all since the find will throw an error immediately.